### PR TITLE
chore(security): neutralize MongoDB URI placeholder to satisfy secret scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/database-name
+# Paste your real URI ONLY in your private .env (never commit).
+# Example (intentionally broken so secret scanners won't match a real credentialed URI):
+# mongo + srv : // <USER> : <PASS> @ <CLUSTER-HOST> / <DB-NAME>
+MONGODB_URI=YOUR_MONGODB_URI
 SESSION_SECRET=your-secure-session-secret-key-here
 JWT_SECRET=your-jwt-secret
 ADMIN_PASSWORD=your-secure-admin-password

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,7 +15,3 @@ paths = [
   '''^attached_assets/''',
   '''^test-results/'''
 ]
-# Explicitly allow the sample placeholder value in .env.example
-regexes = [
-  '''mongodb\+srv:\/\/username:password@cluster\.mongodb\.net\/database-name'''
-]

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,29 @@
+# Environment Setup (Safe Example)
+
+Create a `.env` locally (do not commit). Use your real connection string from MongoDB Atlas.
+
+**IMPORTANT:** Never put a credentialed URI in `.env.example`.
+
+Example pattern (intentionally broken so scanners won't match):
+
+
+mongo + srv : // <USER> : <PASS> @ <CLUSTER-HOST> / <DB-NAME>
+
+
+Set in your private `.env`:
+
+
+MONGODB_URI=<your real URI>
+SESSION_SECRET=<random long string>
+JWT_SECRET=<random long string>
+CLIENT_URL=http://localhost:5173,https://
+<your-vercel-app>.vercel.app
+PORT=5000
+
+Frontend
+
+VITE_API_URL=https://<your-render-backend>
+
+Optional
+VITE_ASSETS_BASE=https://<your-render-backend>/assets
+VITE_ENABLE_PROMO_VIDEO=false


### PR DESCRIPTION
## Summary
- neutralize MongoDB URI placeholder in `.env.example` and add guidance comments
- add safe environment setup guide in `docs/ENV.md`
- simplify gitleaks config, removing explicit allowlist of credentialed URI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run scan:secrets` *(fails: gitleaks not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b07c16462c8331bcf9c2cab869225d